### PR TITLE
Add `log_level` option to config

### DIFF
--- a/flask_cachebuster/__init__.py
+++ b/flask_cachebuster/__init__.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import hashlib
 from pathlib import Path
 
@@ -14,6 +15,8 @@ class CacheBuster:
         self.config = config
         self.extensions = self.config.get('extensions') if self.config else []
         self.hash_size = self.config.get('hash_size') if self.config else HASH_SIZE
+        if self.app is not None:
+            app.logger.setLevel(self.config.get('log_level', logging.INFO) if self.config else logging.INFO)
         if self.app is not None:
             self.register_cache_buster(app, config)
 
@@ -38,6 +41,8 @@ class CacheBuster:
         if not (config is None or isinstance(config, dict)):
             raise ValueError("`config` must be an instance of dict or None")
 
+        app.logger.setLevel(config.get('log_level', logging.INFO) if config else logging.INFO)
+        
         bust_map = {}  # map from an unbusted filename to a busted one
         # http://flask.pocoo.org/docs/0.12/api/#flask.Flask.static_folder
 


### PR DESCRIPTION
I find the debug messages very noisy and I want to be able to turn them off. I've added a config option for `log_level` and set the default log level in the extension to `INFO`.

I've looked at other extensions to see how they may handle the same situation but I did not find an example easily. Flask-Caching uses a logger and not the app.logger. Flask-SQLAlchemy uses something called `warning`. So I am not sure my solution is really the best but I just want to propose this idea mostly rather than have a best practices solution right now.